### PR TITLE
Refactor audio playback logic to 'Instrument'

### DIFF
--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task.xcodeproj/project.pbxproj
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task.xcodeproj/project.pbxproj
@@ -409,8 +409,8 @@
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
@@ -450,8 +450,8 @@
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task.xcodeproj/project.pbxproj
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		5C83C0732A7D4C50002B5E41 /* acoustic_grand_piano-mp3-2-F#4.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 5C83C05B2A7D4C50002B5E41 /* acoustic_grand_piano-mp3-2-F#4.mp3 */; };
 		5CEA59732A8A7CEB00C72165 /* GraphQLClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEA59722A8A7CEB00C72165 /* GraphQLClient.swift */; };
 		5CEA59752A8A82B900C72165 /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEA59742A8A82B900C72165 /* Queries.swift */; };
+		613C00942A8BC8DF007F4524 /* Instrument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613C00932A8BC8DF007F4524 /* Instrument.swift */; };
 		61FB08DF2A8A648700ED5E67 /* PianoKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB08DE2A8A648700ED5E67 /* PianoKey.swift */; };
 /* End PBXBuildFile section */
 
@@ -77,6 +78,7 @@
 		5C83C05B2A7D4C50002B5E41 /* acoustic_grand_piano-mp3-2-F#4.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "acoustic_grand_piano-mp3-2-F#4.mp3"; sourceTree = "<group>"; };
 		5CEA59722A8A7CEB00C72165 /* GraphQLClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLClient.swift; sourceTree = "<group>"; };
 		5CEA59742A8A82B900C72165 /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
+		613C00932A8BC8DF007F4524 /* Instrument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrument.swift; sourceTree = "<group>"; };
 		61FB08DE2A8A648700ED5E67 /* PianoKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PianoKey.swift; sourceTree = "<group>"; };
 		61FB08E02A8A89F800ED5E67 /* SwiftUI-Piano-Recording-Task-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "SwiftUI-Piano-Recording-Task-Info.plist"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -117,6 +119,7 @@
 				5C83C0312A7D3BF4002B5E41 /* ContentView.swift */,
 				5C83C0412A7D3D3E002B5E41 /* MusicalNote.swift */,
 				5C83C03F2A7D3CA9002B5E41 /* Piano.swift */,
+				613C00932A8BC8DF007F4524 /* Instrument.swift */,
 				61FB08DE2A8A648700ED5E67 /* PianoKey.swift */,
 				5C83C0332A7D3BF5002B5E41 /* Assets.xcassets */,
 				5C83C0432A7D4C50002B5E41 /* Sounds */,
@@ -264,6 +267,7 @@
 				61FB08DF2A8A648700ED5E67 /* PianoKey.swift in Sources */,
 				5CEA59752A8A82B900C72165 /* Queries.swift in Sources */,
 				5C83C0422A7D3D3E002B5E41 /* MusicalNote.swift in Sources */,
+				613C00942A8BC8DF007F4524 /* Instrument.swift in Sources */,
 				5C83C0322A7D3BF4002B5E41 /* ContentView.swift in Sources */,
 				5C83C0302A7D3BF4002B5E41 /* SwiftUI_Piano_Recording_TaskApp.swift in Sources */,
 				5C83C0402A7D3CA9002B5E41 /* Piano.swift in Sources */,

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
@@ -1,7 +1,13 @@
 import SwiftUI
 
 struct ContentView: View {
-    let instrument = Instrument(noteRange: 48..<72)
+    let noteRange: NoteRange
+    let instrument: Instrument
+    
+    init() {
+        noteRange = 48..<72
+        instrument = Instrument(noteRange: noteRange)
+    }
 
     var body: some View {
         VStack {
@@ -12,7 +18,7 @@ struct ContentView: View {
                 .cornerRadius(8)
                 .padding(.bottom)
 
-            Piano(noteRange: instrument.noteRange) { midiNumber in
+            Piano(noteRange: noteRange) { midiNumber in
                 instrument.playNote(midiNumber: midiNumber)
             } onStopNote: { midiNumber in
                 instrument.stopNote(midiNumber: midiNumber)

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct ContentView: View {
+    let instrument = Instrument(noteRange: 48..<72)
+
     var body: some View {
         VStack {
             Text("Piano Recorder")
@@ -10,7 +12,11 @@ struct ContentView: View {
                 .cornerRadius(8)
                 .padding(.bottom)
 
-            Piano(noteRange: 48 ..< 72)
+            Piano(noteRange: instrument.noteRange) { midiNumber in
+                instrument.playNote(midiNumber: midiNumber)
+            } onStopNote: { midiNumber in
+                instrument.stopNote(midiNumber: midiNumber)
+            }
         }
         .padding()
         .onAppear {

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
@@ -18,11 +18,14 @@ struct ContentView: View {
                 .cornerRadius(8)
                 .padding(.bottom)
 
-            Piano(noteRange: noteRange) { midiNumber in
-                instrument.playNote(midiNumber: midiNumber)
-            } onStopNote: { midiNumber in
-                instrument.stopNote(midiNumber: midiNumber)
-            }
+            Piano(
+                noteRange: noteRange,
+                onPlayNote: { midiNumber in
+                    instrument.playNote(midiNumber: midiNumber)
+                },
+                onStopNote: { midiNumber in
+                    instrument.stopNote(midiNumber: midiNumber)
+                })
         }
         .padding()
         .onAppear {

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     let instrument: Instrument
     
     init() {
-        noteRange = 48..<72
+        noteRange = 48 ..< 72
         instrument = Instrument(noteRange: noteRange)
     }
 

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -3,17 +3,6 @@ import AVFoundation
 typealias MIDINumber = Int
 typealias NoteRange = CountableRange<MIDINumber>
 
-extension MIDINumber {
-    var pitchClass: MusicalNote {
-        let rawValue = self % MusicalNote.allCases.count
-        return MusicalNote(rawValue: rawValue)!
-    }
-    
-    var octave: Int {
-        return (self / MusicalNote.allCases.count) - 1
-    }
-}
-
 struct Instrument {
     private static let KEY_FADEOUT_IN_SEC: Double = 450 / 1000
 
@@ -44,6 +33,18 @@ struct Instrument {
     }
 }
 
+extension MIDINumber {
+    var pitchClass: MusicalNote {
+        let rawValue = self % MusicalNote.allCases.count
+        return MusicalNote(rawValue: rawValue)!
+    }
+}
+
+private extension MIDINumber {
+    var octave: Int {
+        return (self / MusicalNote.allCases.count) - 1
+    }
+}
 
 private extension NoteRange {
     func createAudioPlayers() -> [MIDINumber: AVAudioPlayer] {

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -27,10 +27,7 @@ struct Instrument {
     }
     
     func playNote(midiNumber: MIDINumber) {
-        guard
-            noteRange.contains(midiNumber),
-            let player = audioPlayers[midiNumber]
-        else { return }
+        guard let player = getAudioPlayer(for: midiNumber) else { return }
         
         player.volume = 1
         player.currentTime = 0
@@ -38,9 +35,15 @@ struct Instrument {
     }
     
     func stopNote(midiNumber: MIDINumber) {
-        guard noteRange.contains(midiNumber) else { return }
+        guard let player = getAudioPlayer(for: midiNumber) else { return }
+
+        player.setVolume(0, fadeDuration: Instrument.KEY_FADEOUT_IN_SEC)
+    }
+    
+    private func getAudioPlayer(for midiNumber: MIDINumber) -> AVAudioPlayer? {
+        guard noteRange.contains(midiNumber) else { return nil }
         
-        audioPlayers[midiNumber]?.setVolume(0, fadeDuration: Instrument.KEY_FADEOUT_IN_SEC)
+        return  audioPlayers[midiNumber]
     }
 }
 

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -27,13 +27,19 @@ struct Instrument {
     }
     
     func playNote(midiNumber: MIDINumber) {
-        guard let player = audioPlayers[midiNumber] else { return }
+        guard
+            noteRange.contains(midiNumber),
+            let player = audioPlayers[midiNumber]
+        else { return }
+        
         player.volume = 1
         player.currentTime = 0
         player.play()
     }
     
     func stopNote(midiNumber: MIDINumber) {
+        guard noteRange.contains(midiNumber) else { return }
+        
         audioPlayers[midiNumber]?.setVolume(0, fadeDuration: Instrument.KEY_FADEOUT_IN_SEC)
     }
 }

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -36,13 +36,11 @@ struct Instrument {
     
     func stopNote(midiNumber: MIDINumber) {
         guard let player = getAudioPlayer(for: midiNumber) else { return }
-
         player.setVolume(0, fadeDuration: Instrument.KEY_FADEOUT_IN_SEC)
     }
     
     private func getAudioPlayer(for midiNumber: MIDINumber) -> AVAudioPlayer? {
         guard noteRange.contains(midiNumber) else { return nil }
-        
         return  audioPlayers[midiNumber]
     }
 }

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -6,8 +6,7 @@ typealias NoteRange = CountableRange<MIDINumber>
 extension MIDINumber {
     var pitchClass: MusicalNote {
         let rawValue = self % MusicalNote.allCases.count
-        let musicalNote = MusicalNote(rawValue: rawValue)
-        return musicalNote!
+        return MusicalNote(rawValue: rawValue)!
     }
     
     var octave: Int {

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -15,7 +15,7 @@ extension MIDINumber {
     }
 }
 
-class Instrument {
+struct Instrument {
     private static let KEY_FADEOUT_IN_SEC: Double = 450 / 1000
 
     let noteRange: NoteRange

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -18,7 +18,7 @@ extension MIDINumber {
 struct Instrument {
     private static let KEY_FADEOUT_IN_SEC: Double = 450 / 1000
 
-    let noteRange: NoteRange
+    private let noteRange: NoteRange
     private let audioPlayers: [MIDINumber: AVAudioPlayer]
     
     init(noteRange: NoteRange) {

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 
-public typealias MIDINumber = Int
-public typealias NoteRange = CountableRange<MIDINumber>
+typealias MIDINumber = Int
+typealias NoteRange = CountableRange<MIDINumber>
 
 extension MIDINumber {
     var pitchClass: MusicalNote {

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -1,0 +1,40 @@
+import AVFoundation
+
+class Instrument {
+    private static let KEY_FADEOUT_IN_SEC: Double = 450 / 1000
+
+    let noteRange: NoteRange
+    private let audioPlayers: [MIDINumber: AVAudioPlayer]
+    
+    init(noteRange: NoteRange) {
+        self.noteRange = noteRange
+        audioPlayers = noteRange.createAudioPlayers()
+    }
+    
+    func playNote(midiNumber: MIDINumber) {
+        guard let player = audioPlayers[midiNumber] else { return }
+        player.volume = 1
+        player.currentTime = 0
+        player.play()
+    }
+    
+    func stopNote(midiNumber: MIDINumber) {
+        audioPlayers[midiNumber]?.setVolume(0, fadeDuration: Instrument.KEY_FADEOUT_IN_SEC)
+    }
+}
+
+
+private extension NoteRange {
+    func createAudioPlayers() -> [MIDINumber: AVAudioPlayer] {
+        var audioPlayers: [MIDINumber: AVAudioPlayer] = [:]
+        self.forEach { midiNumber in
+            let noteName = midiNumber.pitchClass.noteName.replacing("♯", with: "#")
+            let filename = "acoustic_grand_piano-mp3-2-\(noteName)\(midiNumber.octave)"
+            
+            let url = Bundle.main.url(forResource: filename, withExtension: "mp3")!
+            let player = try! AVAudioPlayer(contentsOf: url)
+            audioPlayers[midiNumber] = player
+        }
+        return audioPlayers
+    }
+}

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Instrument.swift
@@ -1,5 +1,20 @@
 import AVFoundation
 
+public typealias MIDINumber = Int
+public typealias NoteRange = CountableRange<MIDINumber>
+
+extension MIDINumber {
+    var pitchClass: MusicalNote {
+        let rawValue = self % MusicalNote.allCases.count
+        let musicalNote = MusicalNote(rawValue: rawValue)
+        return musicalNote!
+    }
+    
+    var octave: Int {
+        return (self / MusicalNote.allCases.count) - 1
+    }
+}
+
 class Instrument {
     private static let KEY_FADEOUT_IN_SEC: Double = 450 / 1000
 

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/MusicalNote.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/MusicalNote.swift
@@ -1,9 +1,9 @@
-public enum MusicalNote: Int, CaseIterable {
+enum MusicalNote: Int, CaseIterable {
     case c = 0, cSharp, d, dSharp, e, f, fSharp, g, gSharp, a, aSharp, b
 }
 
 extension MusicalNote: CustomStringConvertible {
-    public var noteName: String {
+    var noteName: String {
         switch self {
         case .c:        return "C"
         case .cSharp:   return "C♯"
@@ -20,7 +20,7 @@ extension MusicalNote: CustomStringConvertible {
         }
     }
 
-    public var description: String {
+    var description: String {
         return "♪" + noteName
     }
 }

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Piano.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Piano.swift
@@ -1,20 +1,7 @@
 import SwiftUI
 import AVFoundation
 
-public typealias MIDINumber = Int
-public typealias NoteRange = CountableRange<MIDINumber>
 
-extension MIDINumber {
-    var pitchClass: MusicalNote {
-        let rawValue = self % MusicalNote.allCases.count
-        let musicalNote = MusicalNote(rawValue: rawValue)
-        return musicalNote!
-    }
-    
-    var octave: Int {
-        return (self / MusicalNote.allCases.count) - 1
-    }
-}
 
 enum PianoKeyColor {
     case black

--- a/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Piano.swift
+++ b/SwiftUI Piano Recording Task/SwiftUI Piano Recording Task/Piano.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 import AVFoundation
 
-
-
 enum PianoKeyColor {
     case black
     case white
@@ -21,7 +19,6 @@ extension PianoKeyColor {
 typealias NoteCallback = ((_ midiNumber: MIDINumber) -> Void)
 
 struct Piano: View {
-    
     let notesForWhiteKeys: [MIDINumber]
     @State var activeKeys: Set<MIDINumber> = []
 
@@ -83,6 +80,3 @@ struct Piano: View {
         }
     }
 }
-
-
-


### PR DESCRIPTION
Currently the audio playback logic is mixed with the UI logic. Separating this to a new type `Instrument` makes the code cleaner and perhaps better for the candidate (especially given the short time we have in pair-programming sessions)